### PR TITLE
Merging Docs into Main | 1/14 (Part II)

### DIFF
--- a/02 Docs/01 Information/getting-started.md
+++ b/02 Docs/01 Information/getting-started.md
@@ -1,11 +1,5 @@
 <a id="readme-top"></a>
 
-<!-- CSS -->
-
-<style>
-/* Insert any CSS here. */
-</style>
-
 <!-- TITLE -->
 <br />
 <div align="center">

--- a/README.md
+++ b/README.md
@@ -1,13 +1,10 @@
 <a id="readme-top"></a>
 
-<!-- PROJECT LOGO -->
+<!-- TITLE -->
 <br />
 <div align="center">
-  <a href="https://github.com/github_username/repo_name">
-    <img src="images/logo.png" alt="Logo" width="80" height="80">
-  </a>
 
-<h3 align="center">Murder At Supper</h3>
+<h1 align="center">Murder At Supper</h1>
 
   <p align="center">
     Welcome to the official GitHub repository for<br />
@@ -16,400 +13,96 @@
   </p>
 </div>
 
+> Please keep in mind that this README is currently UNDER CONSTRUCTION! To anyone reading this, I would highly recommend you check out the [Getting Started guide](https://github.com/Nicole-Scalera/MaS/blob/main/02%20Docs/01%20Information/getting-started.md) in the 02 Docs folder. -- Nikki, 1/14/25
+
 <!-- TABLE OF CONTENTS -->
 <div style="font-size:16px;">
 <details>
   <summary>Table of Contents</summary>
   <ol>
-    <li><a href="#credits">Credits</a></li>
     <li><a href="#overview">Overview</a></li>
       <ol type="i">
-        <li><a href="#there-is-a-lot-of-text-here-where-do-i-start">There is a LOT of Text Here... Where Do I Start?</a></li>
+      <li><a href="#navigation">Navigation</a></li>
       </ol>
-    <li><a href="#navigation">Navigation</a></li>
+    <li><a href="#for-programmers">For Programmers</a></li>
       <ol type="i">
-        <li><a href="#unfamiliar-with-github">Unfamiliar With GitHub</a></li>
-        <li><a href="#familiar-with-github">Familiar With GitHub</a></li>
+      <li><a href="#a-few-tips-programmers">A few tips...</a></li>
       </ol>
-    <li><a href="#repositories">Repositories</a></li>
-      <ol>
-        <li><a href="#what-is-a-repository">What Is a Repository?</a></li>
-        <li><a href="#how-will-the-repository-be-used">How Will the Repository Be Used?</a></li>
-      </ol>
-    <li><a href="#committing">Committing</a></li>
-      <ol type="i">
-        <li><a href="#what-is-committing">What Is Committing?</a></li>
-        <li><a href="#how-do-i-commit">How Do I Commit?</a></li>
-      </ol>
-    <li><a href="#remote-vs-local">Remote vs. Local</a></li>
-      <ol type="i">
-        <li><a href="#what-does-remote-mean">What Does Remote Mean?</a></li>
-        <li><a href="#what-does-local-mean">What Does Local Mean?</a></li>
-      </ol>
-    <li><a href="#uploading-things-and-making-changes">Uploading Things & Making Changes</a></li>
-      <ol type="i">
-        <li><a href="#i-want-to-upload-files-through-my-browser-remote">I Want to Upload Files Through My Browser (Remote)</a></li>
-        <li><a href="#i-want-to-upload-files-from-my-computer-local">I Want to Upload Files From My Computer (Local)</a></li>
-        <li><a href="#fetch-origin">Fetch Origin</a></li>
-        <li><a href="#push-origin">Push Origin</a></li>
-      </ol>
-    <li><a href="#committing-guidelines">Committing Guidelines</a></li>
-      <ol type="i">
-        <li><a href="#title-and-description">Title and Description</a></li>
-        <li><a href="#commit-example">Commit Example</a></li>
-      </ol>
-    <li><a href="#branching-and-forking">Branching & Forking</a></li>
-      <ol type="i">
-        <li><a href="#to-branch-or-not-to-branch">To Branch, or Not to Branch...</a></li>
-        <li><a href="#why-have-two-different-branches">Why Have Two Different Branches?</a></li>
-        <li><a href="#when-should-i-merge-dev-into-main">When Should I Merge Dev Into Main?</a></li>
-        <li><a href="#other-branches">Other Branches</a></li>
-        <li><a href="#what-the-fork">What the Fork?!</a></li>
-      </ol>
+    <li><a href="#credits">Credits</a></li>
     <li><a href="#acknowledgments">Acknowledgments</a></li>
   </ol>
 </details>
 </div>
 
-<br></br>
+<br>
+
+<!-- OVERVIEW -->
+<div style="font-size:16px;">
+<h2 id="overview">Overview</h2>
+Hello and welcome to the official repository for <i>Murder at Supper</i>. This repository was created on Oct 10, 2024. Please use the navigational bar below to guide your reading experience.
+</div>
+
+<!-- NAVIGATIONAL WIREFRAME -->
+<div style="font-size:16px;">
+
+<h3 id="navigation">Navigation</h3>
+
+For an unguided reading experience, feel free to jump straight into the [02 Docs > 01 Information](https://github.com/Nicole-Scalera/MaS/tree/main/02%20Docs/01%20Information) folder.
+
+> NAVIGATION is under construction. -- Nikki, 1/14/25
+
+</div>
+
+<p align="right">(<a href="#readme-top">back to top</a>)</p>
+
+<br>
+
+<!-- FOR PROGRAMMERS -->
+<div style="font-size:16px;">
+<h2 id="for-programmers">For Programmers</h2>
+
+Greetings to my fellow programmers! If you've never used GitHub before, you're definitely going to want to check out the [Getting Started guide](https://github.com/Nicole-Scalera/MaS/blob/main/02%20Docs/01%20Information/getting-started.md) in this repository.
+
+The relevant sections you'll want to check out are written there as well, with a guide.
+
+<h3 id="a-few-tips-programmers">A few tips...</h3>
+
+* Please be sure to sync your work here often!
+* Make sure to [branch out](https://github.com/Nicole-Scalera/MaS/blob/main/02%20Docs/01%20Information/getting-started.md#branching--forking) (literally) when working on different elements of the project.
+* Be [descriptive](https://github.com/Nicole-Scalera/MaS/blob/main/02%20Docs/01%20Information/getting-started.md#committing-guidelines) in your commits and pull requests.
+
+</div>
+
+<p align="right">(<a href="#navigation">back to navigation</a>)</p>
+
+<br>
 
 <!-- CREDITS -->
-## Credits
+<div style="font-size:16px;">
+<h2 id="credits">Credits</h2>
 
 Epic Epic Games is...
 
-* Nicole Scalera | [Atomic-Atlas](https://github.com/Atomic-Atlas)
+* Nicole Scalera | [Nicole-Scalera](https://github.com/Nicole-Scalera)
 * Ferris Milinazo | [Ferris991](https://github.com/Ferris991)
 * Abby Agostin | [AbigailAgostin](https://github.com/AbigailAgostin)
-* Kendall Pastreich | (insert GitHub later)
+* Kendall Pastreich
 * Alyssa Mazur | [amazurr](https://github.com/amazurrsi)
 * Brenden Moloney | [realBMOLDIGITAL](https://github.com/realBMOLDIGITAL)
 
-<p align="right">(<a href="#readme-top">back to top</a>)</p>
-
-
-<!-- OVERVIEW -->
-<div id="overview" style="font-size:16px;">
-<h2>Overview</h2>
-
-<p style="font-size:16px;">Hello everyone! For easy reading, I've broken the rules up into bite-sized sections.
-
-### There is a LOT of Text Here... Where Do I Start?
-You may be asking yourself, *where should I even start?* Fear not! I've put together a table below that will help you <a href="#navigation">navigate</a> this README.
-
 </div>
 
 <p align="right">(<a href="#readme-top">back to top</a>)</p>
 
-<br></br>
-
-<!-- NAVIGATIONAL WIREFRAME -->
-<div id="navigation" style="font-size:16px;">
-
-<h2>Navigation</h3>
-
-Take a look at the following questions to navigate this README. Each choice will tailor your reading experience.
-
-<div style="font-size:16px;">
-  <ol>
-    <li>
-      <strong>Are you familiar with GitHub?</strong>
-      <br>
-      <a href="#unfamiliar-with-github" style="margin-left:12px;">No, I need an introduction</a> |
-      <a href="#familiar-with-github">Yes, I am very/pretty familiar</a>
-    </li>
-  </ol>
-  <p></p> 
-  <p>
-
-  </p>
-
-</div>
-
-</div>
-
-<p align="right">(<a href="#readme-top">back to top</a>)</p>
-
-<br></br>
-
-
-<!-- UNFAMILIAR WITH GITHUB -->
-<div id="unfamiliar-with-github" style="font-size:16px;">
-  <h2>Unfamiliar With Github</h2>
-  <p>No problem! I am happy to help out. Here are the sections I would recommend you read:</p>
-  <ol>
-    <li><a href="#repositories">Repositories</a></li>
-    <ul>
-      <li>This section covers the basics of this repository and how to interact with it.</li>
-    </ul>
-    <li><a href="#committing">Committing</a></li>
-    <li><a href="#remote-vs-local">Remote vs. Local</a></li>
-    <li><a href="#uploading-things--making-changes">Uploading Things & Making Changes</a></li>
-    <ul>
-      <li>You will most likely be uploading <a href="#i-want-to-upload-files-through-my-browser-remote">remotely</a>, especially if you are a Writer, Artist, or Designer.</li>
-      <li>However, you can also upload things <a href="#i-want-to-upload-files-from-my-computer-local">locally</a>, but remote is easier if you're a beginner.</li>
-    </ul>
-    <li><a href="#committing-guidelines">Committing Guidelines</a></li>
-    <ul>
-      <li>Writers and Artists can commit directly to the <strong>main branch</strong>, as long as they are not changing the <strong>00 Unity Proj</strong> folder.</li>
-      <li>If you are curious, I explain in <a href="#branching--forking">Branching & Forking</a> section (optional).</li>
-    </ul>
-  </ol>
-
-</div>
-
-<p align="right">(<a href="#navigation">Back to Navigation</a>)</p>
-
-<!-- FAMILIAR WITH GITHUB -->
-<div id="familiar-with-github" style="font-size:16px;">
-  <h2>Familiar With Github</h2>
-  <p>Good to hear! With that said, here are the sections I would recommend you read:</p>
-  <ol>
-    <li><a href="#how-will-the-repository-be-used">How Will the Repository Be Used?</a></li>
-    <li><a href="#remote-vs-local">Remote vs. Local</a></li>
-    <ul>
-      <li>May want to brush up on this if you don't know the difference between the remote and local repo.</li>
-    </ul>
-    <li><a href="#uploading-things--making-changes">Uploading Things & Making Changes</a></li>
-    <ul>
-      <li>If you are a Writer, Artist, or Designer, you can upload things <a href="#i-want-to-upload-files-through-my-browser-remote">remotely</a> or <a href="#i-want-to-upload-files-from-my-computer-local">locally</a>, your choice.
-      <li>However, if you are a Programmer, you should upload <a href="#i-want-to-upload-files-from-my-computer-local">locally</a>.</li>
-    </ul>
-    <li><a href="#committing-guidelines">Committing Guidelines</a></li>
-    <ul>
-      <li>This section coincides with <a href="#push-origin">pushing</a> and <a href="#fetch-origin">pulling</a>.</li>
-    </ul>
-    <li><a href="#branching--forking">Branching & Forking</a></li>
-    <ul>
-      <li>Branching is the most important here, so please read carefully.</li>
-      <li>You can fork if you want, but not required. Just thought I would distinguish the two.</li>
-    </ul>
-  </ol>
-
-</div>
-
-<p align="right">(<a href="#navigation">Back to Navigation</a>)</p>
-
-<br></br>
-
-<!-- OVERVIEW -->
-## Repositories
-
-### What Is a Repository?
-
-A repository is what you are looking at right now! It's a central location where you can keep all of your files.
-
-<img src="02 Documentation\00 Assets\README\repository_def.png" width="500"></img>
-
-In the case of GitHub, we can all contribute to this same repository to track and synchronize our work, even when we're apart.
-
-### How Will the Repository Be Used?
-
-You can interact with this repository <a href="#what-does-remote-mean">remotely through browser</a> or <a href="#what-does-local-mean">locally through your machine</a> via the [GitHub Desktop](https://desktop.github.com/download/) application.
-
-You will make changes to the repository through <a href="#committing">**commits**</a> and <a href="#pull-requests">**pull requests**</a>.
-
-<div style="font-size:16px;">
-
-The purpose behind this repository is to...
-
-  <ol>
-    <li>Quickly and easily share files</li>
-    <li>Track progress and maintain an organized workflow</li>
-    <li>Periodically create stable builds of our game</li>
-    <li>Systematically identify and fix errors, *without* corrupting said builds</li>
-    <li>Develop comprehensive and user-friendly documentation</li>
-  </ol>
-
-Please check out the sections below for all the information on this repository.
-
-</div>
-
-<p align="right">(<a href="#readme-top">back to top</a>)</p>
-
-<br></br>
-
-
-<!-- COMMITTING -->
-## Committing
-
-### What Is Committing?
-Everytime you make changes to your repository, it is called a "commit."
-
-Commits can be thought of as a 'Save Game' function.
-
-<img src="02 Documentation\00 Assets\README\quicksave_meme.png" width="400"></img>
-
-In the case of GitHub, they act as these little snapshots of your respository at specific times in its progression.
-
-Just like in a video game, you should "save" your progress often by making new commits. This helps you and team members keep track of updates.
-
-Additionally, in the event of project issues, you can roll back changes and return to a previous version of your project.
-
-### How Do I Commit?
-
-There are two ways to commit to the GitHub:
-1. Remotely through your browser
-2. Locally from your machine
-
-You can learn about the <a href="#remote-vs-local">differences between these methods</a> and <a href="#uploading-things--making-changes">how to follow them</a> in the sections below.
-
-<p align="right">(<a href="#readme-top">back to top</a>)</p>
-
-<br></br>
-
-<!-- REMOTE VS. LOCAL -->
-## Remote vs. Local
-
-### What Does Remote Mean?
-"Remote" refers to a version of your project that is stored on a server everyone has access to (namely, the GitHub website).
-
-It's like a shared Google Docs file versus a personal Word Doc. The remote repository is the shared Google Document that all team members can collaborate on in real time.
-
-This workflow concept can be visualized through [this diagram](https://git-scm.com/book/en/v2/Getting-Started-About-Version-Control) from the official [Progit book](https://git-scm.com/book/en/v2).
-
-<img src="02 Documentation\00 Assets\README\centralized_ver_control_diagram.png" width="600"></img>
-
-However, this diagram *only* applies if you're making edits exclusively through the browser. If you want to make edits from your machine, take a look at the section below.
-
-### What Does Local Mean?
-In contrast, "Local" surrounds the idea of everything that is locally available to *you* and only you. In other words, your personal machine. The [diagram](https://git-scm.com/book/en/v2/Getting-Started-About-Version-Control) below illustrates this concept.
-
-<img src="02 Documentation\00 Assets\README\distributed_ver_control_sys.png" width="500"></img>
-
-As you can see, Computer A and Computer B both sync to the same remote repository, but have their own individual versions of the project. That way they can make changes and not corrupt the repository altogether. When you are ready, you can sync your local repository with the remote repository through <a href="#push-origin">pushing</a> and <a href="#fetch-origin">pulling</a>.
-
-Note: To Programmers reading this, keep in mind that the workflow may be manipulated through different branches to ensure the stability of the project. As of right now, though, aforementioned concept illustrates the bare bones level of this project.
-
-<p align="right">(<a href="#readme-top">back to top</a>)</p>
-
-<br></br>
-
-<!-- UPLOADING THINGS & MAKING CHANGES -->
-## Uploading Things & Making Changes
-
-Preface: If you are a Developer and you plan on making changes to the 00 Unity Proj folder, please see the <a href="#branching--forking">Branching & Forking</a> section.
-
-### I Want to Upload Files Through My Browser (Remote)
-
-The people committing remotely will most likely be Writers and Artists. To commit remotely, visit [this repository](https://github.com/Atomic-Atlas/MaS) on [GitHub.com](https://github.com/) and upload files to the correct folders.
-
-<img src="02 Documentation\00 Assets\README\create_or_upload.png" width="600"></img>
-
-Be sure to enter the <a href="#title-and-description">title and description</a> of your change.
-
-<img src="02 Documentation\00 Assets\README\summary_box_remote.png" width="600"></img>
-
-### I Want to Upload Files From My Computer (Local)
-
-The people committing locally will most likely be Programmers. To commit locally, use the [GitHub Desktop](https://desktop.github.com/download/) application.
-
-It follows a very similar process, although it actively tracks your changes on your computer, and shows the difference between the remote repository (what's on the GitHub website) and the local repository (your machine).
-
-Here is a screenshot of my local repository for *Murder at Supper* open on the GitHub Desktop app.
-
-<img src="02 Documentation\00 Assets\README\ghd_interface.png" width="700"></img>
-
-In the upper-left corner, right beneath the repository name, you can find the changes you've made. All changes will be selected automatically, but you can uncheck whatever you'd like to not be uploaded to the repository.
-
-### Fetch Origin
-Sometimes it's best to pull from the repository ("fetch origin") before you push anything into it, which can be done by clicking the "Fetch Origin" button.
-
-<img src="02 Documentation\00 Assets\README\fetch_origin.png" width="700"></img>
-
-This takes in any new changes from the remote repository and adds them to your local repo.
-
-### Push Origin
-Like the last method, you will be prompted to create a <a href="#title-and-description">title and description</a> for your commit.
-
-If you are confident on these edits, and are ready to submit them to the main branch of the repository, you can click "Push Origin."
-
-<img src="02 Documentation\00 Assets\README\push_origin.png" width="700"></img>
-
-This command will sync your local and remote copies together.
-
-<p align="right">(<a href="#readme-top">back to top</a>)</p>
-
-<br></br>
-
-<!-- COMMITTING GUIDELINES -->
-## Committing Guidelines
-
-### Title and Description
-Regardless of which method you choose, you will always be prompted for a title and description of your changes. PLEASE, for your sake and everyone else's, add a description!
-
-Adding a description will...
-1. Eliminate the risk of forgetting what you were doing
-2. Inform others of your changes (that way you don't have to reexplain yourself when you may be unavailable).
-3. Make it easy to rollback changes.
-
-### Commit Example
-Here is an example of what you might enter when you are making changes to the repository.
-
-- **Title:** Created README<br>
-- **Description:**
-  - I created a README.md file at the root of the project.
-  - This is intended to inform any viewers and contributors of what the project is about.
-  - It contains:
-    - Credits for Epic Epic Games
-    - Description of GitHub key terms
-    - Information on how to interact with the repository
-    - and more
-
-Remember: you're *not* writing the declaration of independence. Just a brief overview of what changes you've made, why you made them, what might be incomplete, what needs revisions, etc.
-
-If you're a Writer/Artist and you're commiting to any folder that is *not* the 00 Unity Proj folder at the top of the repository, then you can commit to the main branch. *However!!!!!* If you are a Programmer, please see the <a href="#branching--forking">Branching & Forking</a> section.
-
-<p align="right">(<a href="#readme-top">back to top</a>)</p>
-
-<br></br>
-
-<!-- BRANCHING & FORKING -->
-## Branching & Forking
-
-### To Branch, or Not to Branch...
-Branching is an essential concept for the developer-side of things; namely, anyone working with the game's project files. For Writers and Artists, you can ignore this section and focus on committing to the main branch.
-
-For anyone making changes to the 00 Unity Proj folder, please make sure your project is set to run on the `dev` branch. You can switch from `main` to `dev` in the GitHub Desktop application.
-
-Changes that are made on `dev` can be turned into a pull request, which is then approved for merging into the `main` branch.
-
-### Why Have Two Different Branches?
-We have two different branches that serve different purposes.
-
-**Main Branch:** The `main` branch is like the home base of your repository. It is intended to track your latest stable project.
-
-**Dev Branch:** The `dev` acts as an extension of `main`. It is designed to track your latest working project, while allowing you to add new features onto it.
-
-God forbid anything crazy happens to your Unity files, it will *not* corrupt the main branch. You can think of it as cutting off the rotted piece of an apple. You still have the rest of the apple to work with.
-
-### When Should I Merge `Dev` Into `Main`?
-After making a few changes to your game on `dev`, and the project is in a stable, playable state, you can go ahead and push the changes onto the `main` branch.
-
-This will create a new stable version that can then be cloned again and worked on in `dev`. Working with several different branches allows you to build off of `main` without the risk of messing anything up.
-
-
-### Other Branches
-Dev is not the only extension branch that you are allowed to use. In fact, I would encourage you to use more! This is what's known as "feature branching."
-
-Different features, bugs, and any other kind of edits may require their own branch. For example, Programmer A may work on creating a narrative mechanic, while Programmer B is working on a fighting mechanic.
-
-Likewise, Programmer A would be commmitting changes to the `dialogue-loop` branch, while Programmer B would commit changes to the `combat-kick-feature` branch. Once each of them are confident on their changes, they would merge that branch with the `main` branch.
-
-### What the Fork?!
-Forking is a common term used on GitHub, and it surrounds the idea of creating a whole new repository that is a copy of another one. This is seperate from a local and remote repository, as the two separate pieces (local and remote) are connected under one larger repository.
-
-You can fork this repository if you want to make some big changes on your own without directly affecting the original repository, but it's not needed. I just wanted to let you know that this option was here for any big changes that you wanted to make, which can be completed *without* harming the project entirely.
-
-Forking is better for experimentation. But if you are planning on making something that you will use in later stages of the project, you will want to go with branching.
-
-<p align="right">(<a href="#readme-top">back to top</a>)</p>
+<br>
 
 <!-- ACKNOWLEDGMENTS -->
-## Acknowledgments
+<div style="font-size:16px;">
+<h2 id="acknowledgments">Acknowledgments</h2>
 
 * This README was authored by Nicole Scalera ([Atomic-Atlas](https://github.com/Atomic-Atlas)).
 * I started this README file thru a template from the popular repository, [Best-README-Template](https://github.com/othneildrew/Best-README-Template), by [othneildrew](https://github.com/othneildrew) on GitHub.
 * Many edits have been made to make it different and fit a sufficient README for *Murder at Supper* by Epic Epic Games.
+</div>
 
 <p align="right">(<a href="#readme-top">back to top</a>)</p>


### PR DESCRIPTION
### Overview
- Pulling the latest version of [`docs`](https://github.com/Nicole-Scalera/MaS/tree/docs) into [`main`](https://github.com/Atomic-Atlas/MaS/tree/main).

### In-depth Details
- This pull request comes with regard to two commits to the repository's documentation on 1/14.
     - More specifically, the [Getting Started](https://github.com/Nicole-Scalera/MaS/blob/main/02%20Docs/01%20Information/getting-started.md) guide and the main [README](https://github.com/Nicole-Scalera/MaS/blob/main/README.md).
- See the individual commits for more information.
     1. ["getting-started.md | Removed CSS Section"](https://github.com/Nicole-Scalera/MaS/commit/e0627fef01f2f97666b7fba3a2b456251fdb6192) (Commit e0627fef01f2f97666b7fba3a2b456251fdb6192)
     2. ["Major update to README | 1/14"](https://github.com/Nicole-Scalera/MaS/commit/a6d55018367ede19b3bb423b0f536c79357a76e1) (Commit a6d55018367ede19b3bb423b0f536c79357a76e1)